### PR TITLE
bugfix - set fields before attempting to append options

### DIFF
--- a/apps/end-tenancy/controllers/address-lookup.js
+++ b/apps/end-tenancy/controllers/address-lookup.js
@@ -201,12 +201,12 @@ module.exports = class AddressLookup extends BaseController {
   }
 
   post(req, res, callback) {
-    if (req.params.action === 'lookup') {
-      this.getValues(req, res, () => {});
-    }
     this.options.fields = this.getFields(req);
     this.validator = dataValidator(this.options.fields);
     this.formatter = dataFormatter(this.options.fields, this.options.defaultFormatters);
+    if (req.params.action === 'lookup') {
+      this.getValues(req, res, () => {});
+    }
     super.post(req, res, callback);
   }
 


### PR DESCRIPTION
As fields are dynamically added this needs to be done before attempting to append values to options. This is due to multi-instance