### PR TITLE
Bugfix LCS-145  - editing a tenant from confirm page

### DIFF
--- a/apps/end-tenancy/controllers/loop.js
+++ b/apps/end-tenancy/controllers/loop.js
@@ -34,6 +34,7 @@ module.exports = class LoopController extends DateController {
   get(req, res, callback) {
     if (!req.params.action ||
       Object.keys(this.options.subSteps).indexOf(req.params.action) === -1 ||
+      !req.params.edit &&
       _.some(this.options.subSteps[req.params.action].prereqs, prereq =>
         req.sessionModel.get(prereq) === undefined
       )


### PR DESCRIPTION
Currently when clicking edit tenant date left, the page is redirected to the start of the tenant loop so there is no easy way to amend just one piece of information

* check if req.params.edit is truthy before redirection logic