### PR TITLE
Amend the path to hof-template-partials translations files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-apps/*/translations/en
+apps/**/translations/en
 node_modules
 npm-debug.log
 public

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "browserify": "browserify ./assets/js/index.js > ./public/js/bundle.js",
     "create:public": "mkdir -p ./public/js ./public/css ./public/images",
     "sass": "node-sass ./assets/scss/app.scss ./public/css/app.css --include-path ./node_modules",
-    "hof-transpile": "hof-transpiler ./apps/**/translations/src -w --shared ./node_modules/hof-template-partials/translations",
+    "hof-transpile": "hof-transpiler ./apps/**/translations/src -w --shared ./node_modules/hof-template-partials/translations/src",
     "prepareapp": "npm run create:public; npm run sass; npm run browserify; npm run copy:images; npm run hof-transpile",
     "postinstall": "bash -c 'if [[ ${NODE_ENV} != production ]]; then npm run prepareapp; fi;'"
   },


### PR DESCRIPTION
Since changes were made to hof-template-partials, `/translations` now… contains `index.js`

The path used to pull in the json files from `/translations` included `index.js`, which is
not valid (or even) json. Therefore by updating the path to point at only `/translations/src`
we omit the `index.js` file