### PR TITLE
Upgrade to hof v12.1.1 & hof-theme-govuk 2.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 npm-debug.log
 public
 .idea
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
     "postinstall": "hof-build"
   },
   "dependencies": {
-    "hof": "^12.0.4",
+    "hof": "^12.1.1",
     "hof-behaviour-address-lookup": "^1.1.0",
     "hof-behaviour-summary-page": "^3.0.0",
     "hof-build": "^1.3.3",
     "hof-component-date": "^1.1.0",
-    "hof-theme-govuk": "^2.0.3",
     "hof-model": "^3.1.0",
-    "hogan.js": "^3.0.2",
+    "hof-theme-govuk": "^2.0.4",
     "hof-util-countries": "^1.0.0",
+    "hogan.js": "^3.0.2",
     "jquery": "^3.1.1",
     "lodash": "^4.17.4",
     "moment": "^2.17.1",


### PR DESCRIPTION
Some reasons for this
1. There have been some improvements to hof-template-mixins, e.g. making the year field bigger.  I wanted to capture this to resolve an old bug in end-tenancy
2. I'm going to pick up a story for end-tenancy so I thought it would be a good idea to update hof before I do.