### PR TITLE
Upgrade to hof-build 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "hof": "^12.1.1",
     "hof-behaviour-address-lookup": "^1.1.0",
     "hof-behaviour-summary-page": "^3.0.0",
-    "hof-build": "^1.3.3",
+    "hof-build": "^1.6.0",
     "hof-component-date": "^1.1.0",
     "hof-model": "^3.1.0",
     "hof-theme-govuk": "^2.0.4",


### PR DESCRIPTION
- Because 1.3.3 is old
- there are a lot of useful features in the latest version e.g. watching markdown, having a separate .env file