### PR TITLE
Ensure 'change' buttons link to the correct url.

### DIFF
--- a/apps/end-tenancy/acceptance/features/confirm.js
+++ b/apps/end-tenancy/acceptance/features/confirm.js
@@ -21,6 +21,15 @@ Scenario('I see the correct table information if I am requesting an NLDP', funct
   confirmPage.checkData('request-notice');
 });
 
+Scenario('I do not see fields for information I have  not entered', function *(
+  I,
+  confirmPage
+) {
+  yield confirmPage.setSessionData(steps.name, 'request-notice');
+  yield I.refreshPage();
+  I.dontSee('nationality');
+});
+
 Scenario('I am redirected to the declaration page when I submit the confirm page', function *(
   I,
   confirmPage
@@ -28,4 +37,32 @@ Scenario('I am redirected to the declaration page when I submit the confirm page
   yield confirmPage.setSessionData(steps.name, 'request-notice');
   yield I.submitForm();
   I.seeInCurrentUrl('/declaration');
+});
+
+Scenario('I am redirected to the property-address page when I click the Property address change button', function *(
+  I
+) {
+  I.amOnPage('/');
+  yield I.completeToStep('/confirm', {
+    what: 'request',
+    'property-address': '123 Example Street Example',
+    'tenancy-start-day': '11',
+    'tenancy-start-month': '11',
+    'tenancy-start-year': '1111',
+    'landlord-name': 'Fred Bloggs',
+    'landlord-company': 'UK Home Office',
+    'landlord-email-address': 'sterling@archer.com',
+    'landlord-phone-number': '01234567890',
+    'landlord-address': '123 Example Street Example',
+    tenants: {
+      0: {
+        name: 'Sterling Archer',
+        'date-of-birth': '1980-11-11',
+      }
+    },
+    name: 'John Smith',
+  });
+  I.seeInCurrentUrl('/confirm');
+  I.click('a#property-address-change');
+  I.seeInCurrentUrl('/property-address');
 });


### PR DESCRIPTION
The links in the change buttons were only being defined if the `step` that the field was from had a `field` property. Steps that use the Address Lookup behaviour and have no other fields do not have a `fields` property.