### PR TITLE
Reduces postcode width

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -186,3 +186,7 @@ ul {
 .no-new-line {
   margin-bottom: 0;
 }
+
+input[name*="postcode"] {
+  @extend .form-control-1-4;
+}


### PR DESCRIPTION
This is using the govuk elements form styles defined here: https://govuk-elements.herokuapp.com/form-elements/example-form-elements/

The selector will be reliable because postcode field configuration is driven from the address lookup behaviour, and so the name of the fields will always contain `postcode`. There are some old browsers that won't support the selector, but they will revert to a standard width field which is no big deal.

**before**
![screen shot 2018-03-06 at 14 57 24](https://user-images.githubusercontent.com/12494656/37039188-bf0b81e6-214e-11e8-9cf0-c5b1c3e956ec.png)

**after**
![screen shot 2018-03-06 at 14 57 31](https://user-images.githubusercontent.com/12494656/37039203-c71c735e-214e-11e8-8610-f99f64331b27.png)
