### PR TITLE
Use default govuk h1 styling

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -76,10 +76,6 @@ $path: "../img/";
   margin: 1em 0em;
 }
 
-h1 {
-  @include bold-24;
-}
-
 .form-label-bold {
   @include core-19;
 }


### PR DESCRIPTION
Previously, we were overriding the govuk h1 styling by making it smaller.  This was against the standards and not as accessible