### PR TITLE
[LCS-464] - Update summary & pdf labels

### DIFF
--- a/apps/end-tenancy/acceptance/features/confirm.js
+++ b/apps/end-tenancy/acceptance/features/confirm.js
@@ -39,17 +39,18 @@ Scenario('I am redirected to the declaration page when I submit the confirm page
   I.seeInCurrentUrl('/declaration');
 });
 
-Scenario('I am redirected to the property-address page when I click the Property address change button', function *(
+Scenario('I am redirected to the property-address page when I click the Property address change button', (
   I
-) {
+) => {
   I.amOnPage('/');
-  yield I.completeToStep('/confirm', {
+  I.completeToStep('/confirm', {
     what: 'request',
     'property-address': '123 Example Street Example',
     'tenancy-start-day': '11',
     'tenancy-start-month': '11',
     'tenancy-start-year': '1111',
     'landlord-name': 'Fred Bloggs',
+    'who': 'landlord',
     'landlord-company': 'UK Home Office',
     'landlord-email-address': 'sterling@archer.com',
     'landlord-phone-number': '01234567890',

--- a/apps/end-tenancy/translations/src/en/fields.json
+++ b/apps/end-tenancy/translations/src/en/fields.json
@@ -120,39 +120,40 @@
   },
   "landlord-name": {
     "label": "Your full name",
-    "summary": "Name"
+    "summary": "Landlord name"
   },
   "landlord-company": {
     "label": "Your company name",
     "hint": "If you don't have one, leave this blank",
-    "summary": "Company name"
+    "summary": "Landlord's company name"
   },
   "landlord-email-address": {
     "label": "Your email address",
-    "summary": "Email"
+    "summary": "Landlord's email"
   },
   "landlord-phone-number": {
     "label": "Your phone number",
-    "summary": "Phone number"
+    "summary": "Landlord's phone number"
   },
   "agent-name": {
     "label": "Your full name",
-    "summary": "Name"
+    "summary": "Agent's Name"
   },
   "agent-company": {
     "label": "Your company name",
-    "summary": "Company name"
+    "summary": "Agent's company name"
   },
   "agent-email-address": {
     "label": "Your email address",
-    "summary": "Email address"
+    "summary": "Agent's email address"
   },
   "agent-phone-number": {
     "label": "Your phone number",
-    "summary": "Phone number"
+    "summary": "Agent's phone number"
   },
   "landlord-name-agent": {
-    "label": "What’s the landlord's name?"
+    "label": "What’s the landlord's name?",
+    "summary": "Landlord's name"
   },
   "landlord-address-select": {
     "label": {
@@ -163,13 +164,15 @@
     }
   },
   "landlord-address": {
-    "label": "Address"
+    "label": "Address",
+    "summary": "Landlord's address"
   },
   "use-previous-address": {
     "label": "Use the address of the rental property I provided earlier"
   },
   "agent-address": {
-    "label": "Address"
+    "label": "Address",
+    "summary": "Agent's address"
   },
   "agent-address-select": {
     "label": "Select the address from the list."


### PR DESCRIPTION
- Add prefix of landlord and agent to appropriate sections

To change the name of a label that appears on a field on the summary page, you need to provide a summary value so that takes precedence over the others, see here
https://github.com/UKHomeOffice/end-tenancy/blob/master/apps/end-tenancy/behaviours/summary.js#L49