### PR TITLE
SD-43: Update readme for redeployment to check new file-vault version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is built with [HOF-Bootstrap](https://github.com/UKHomeOffice/hof-b
 
 ## Getting started
 
-Get the project from Github
+Get the project from Github.
 ```bash
 $ git clone git@github.com:UKHomeOffice/end-tenancy.git && cd end-tenancy
 ```


### PR DESCRIPTION
Jira ticket: https://collaboration.homeoffice.gov.uk/jira/browse/SD-43

What: Redeploying end-tenancy to check it works on dev with the new version of file-vault. The file-vault version has been changed in the kube-end-tenency repo (https://github.com/UKHomeOffice/kube-end-tenancy/pull/77).

Why: To test the new version of file-vault is still compatible with the HOF services that use it.