### PR TITLE
SD-725: Upgrade Node Version to 14

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ type: kubernetes
 steps:
 - name: build
   pull: if-not-exists
-  image: node:10
+  image: node:14
   commands:
   - npm --loglevel warn install
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10"
+  - "14"
 
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.11-alpine
+FROM node:14-alpine
 
 RUN apk upgrade --no-cache
 RUN addgroup -S app

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "https://github.com/UKHomeOffice/end-tenancy"
   },
+  "engines": {
+    "node": "14.16.1"
+  },
   "license": "./LICENSE",
   "readme": "./README.md",
   "scripts": {


### PR DESCRIPTION
**Jira Ticket**: https://collaboration.homeoffice.gov.uk/jira/browse/SD-723
	
**Changes**

- Updated image in drone pipeline build step to node:14
- Changed docker image from node:10.11-alpine to node:14-alpine.
- Updated package.json to include node version "14.16.1"
- Updated .travis.yml to use node-js 14