### PR TITLE
SD 723 Update node version and Cookie name correction

### DIFF
--- a/Dockerfile-acceptance
+++ b/Dockerfile-acceptance
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:14
 
 WORKDIR /test
 

--- a/apps/end-tenancy/translations/src/en/cookies.json
+++ b/apps/end-tenancy/translations/src/en/cookies.json
@@ -7,7 +7,7 @@
     ],
     "rows": [
       [
-        "hof.sid",
+        "hod.sid",
         "Stores a session ID and temporarily stores data you enter to enable you to make an application",
         "When you close your browser"
       ],

--- a/apps/end-tenancy/views/content/cookies.md
+++ b/apps/end-tenancy/views/content/cookies.md
@@ -46,6 +46,6 @@ Session cookies are downloaded each time you visit the service and deleted when 
 
 | Name             |    Purpose                    |  Expires   |
 |:-----            |:--------------------------    |:---------  |
-| hof.sid        | Stores a session ID and temporarily stores data you enter to enable you to make an application | When you close your browser |
+| hod.sid        | Stores a session ID and temporarily stores data you enter to enable you to make an application | When you close your browser |
 | hof-wizard-sc    | Tells us when your session starts so we can tell you if it expires | When you close your browser |
 | hof-cookie-check | Tells us you have already allowed cookies so we don’t need to ask you again | When you close your browser |

--- a/apps/end-tenancy/views/content/cookies.md
+++ b/apps/end-tenancy/views/content/cookies.md
@@ -1,7 +1,3 @@
-# Cookies
-
-This service puts small files (known as ‘cookies’) onto your computer in order to:
-
 * remember what messages you’ve seen so you’re not shown them again
 * understand how you use the service so we can update and improve it
 * temporarily store information you enter to support your application

--- a/apps/end-tenancy/views/cookies.html
+++ b/apps/end-tenancy/views/cookies.html
@@ -1,0 +1,6 @@
+{{<partials-page}}
+  {{$header}}{{#t}}Cookies{{/t}}{{/header}}
+  {{$page-content}}
+    {{#markdown}}cookies{{/markdown}}
+  {{/page-content}}
+{{/partials-page}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -421,9 +421,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.885.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.885.0.tgz",
-      "integrity": "sha512-V7fS53HkLYap+mt00frWB516HZV34C5pHNhBs/Het3Vgl7A0GbCpJs07G4FOIT9ioJ38+k9McscOzXG++1rWMQ==",
+      "version": "2.889.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.889.0.tgz",
+      "integrity": "sha512-+v77GmIJKXT3GMDg/HF9x8c7RSVU8Imfp/0n0Tuzf5AAE6eavpD3xzHABiK9zO9f+T8XzJDytl66UQ33YXavng==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -7326,9 +7326,9 @@
       }
     },
     "underscore": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.0.tgz",
-      "integrity": "sha512-sCs4H3pCytsb5K7i072FAEC9YlSYFIbosvM0tAKAlpSSUgD7yC1iXSEGdl5XrDKQ1YUB+p/HDzYrSG2H2Vl36g=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "unpipe": {
       "version": "1.0.0",


### PR DESCRIPTION
**Jira Ticket:** https://collaboration.homeoffice.gov.uk/jira/browse/SD-723

**Changes:**

- Cookie name changed from hof.sid to hod.sid in cookies.json and cookies.md to be inline with acceptance test default.
- Remove heading in cookies.md to correct double heading error. 
- Upgrade Node Version to 14 for acceptance tests (Dockerfile-acceptance file).
- Updated package-lock.json after Node 14 update.