### PR TITLE
SD-779: Updated hof-behaviour emailer to fix vulnerability in nodemailer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3349,12 +3349,12 @@
       }
     },
     "hof-behaviour-emailer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hof-behaviour-emailer/-/hof-behaviour-emailer-2.2.0.tgz",
-      "integrity": "sha512-Bk4hXH/eN85D0WuPlXhj9wUCyz7Q6RS6TwTfmc5VbubQMBy+5Rxp4n6YR/HMYug3mNflE34V7P0i7FAS8UdGjg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/hof-behaviour-emailer/-/hof-behaviour-emailer-2.2.1.tgz",
+      "integrity": "sha512-FCMbeiwlFvZX3/KC1cvpEe/tE4zTo4/b8mWoU69E0McT+mPBAW5onnRUDyB4lruPSdDFE6WDjrMAtSn8UhL2YQ==",
       "requires": {
         "debug": "^2.6.1",
-        "hof-emailer": "^2.0.0",
+        "hof-emailer": "^2.1.1",
         "hogan.js": "^3.0.2"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "debug": "^3.1.0",
     "hof": "^18.2.0",
     "hof-behaviour-address-lookup": "^2.2.2",
-    "hof-behaviour-emailer": "^2.2.0",
+    "hof-behaviour-emailer": "^2.2.1",
     "hof-behaviour-summary-page": "^3.3.0",
     "hof-build": "^2.0.0",
     "hof-component-date": "^1.1.0",


### PR DESCRIPTION
**Changes**	

- Updated hof-behaviour-emailer to version 2.2.1 to fix vulnerability in nodemailer via hof-emailer.