### PR TITLE
Upgraded hof-middlware to v2.2.4 to fix redirection to malicious sites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3581,9 +3581,9 @@
       }
     },
     "hof-middleware": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/hof-middleware/-/hof-middleware-2.2.3.tgz",
-      "integrity": "sha512-Oiwuy60inZQy4rjoWVcYtseJ8EaF5y40iuumWMaQ0MTjewq+9rgmFzATMBT51gnDlADn9esWTZH5Yuf06HwVuQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/hof-middleware/-/hof-middleware-2.2.4.tgz",
+      "integrity": "sha512-XtuxxVyeJGkdtoh+dz0NfiBlDx9tgTvfAub2flO/U984LPgr0lLOGFhIzxFA0uChNup9tMv0ehsWV9qDzCLBRA==",
       "requires": {
         "lodash": "^4.13.1",
         "urijs": "^1.19.2"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "hof-behaviour-summary-page": "^3.3.0",
     "hof-build": "^2.0.0",
     "hof-component-date": "^1.1.0",
+    "hof-middleware": "^2.2.4",
     "hof-model": "^3.1.2",
     "hof-template-partials": "^5.4.1",
     "hof-theme-govuk": "^5.2.1",


### PR DESCRIPTION
**What**
Upgraded hof-middlware to v2.2.4 

**Why**
Applications using this library could be vulnerable to a redirection exploit where an attacker can use a Home Office page to redirect someone to their malicious site

**How**
In hof-middleware ensure URLs are relative paths – i.e. they start with a single / character. Absolute URLs starting with // will be rejected.

**Test**
Unit test and url test (for example entering https://dev.notprod.ending-a-tenancy.homeoffice.gov.uk//bbc.co.uk should not redirect to bbc sit)