### PR TITLE
UKVIET-41: PDF Content Changes for all Routes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -221,6 +221,7 @@ steps:
     environment:
       NOTIFY_STUB: true
     commands:
+      - export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
       - export ACCEPTANCE_HOST_NAME=https://ukviet-$${DRONE_SOURCE_BRANCH}.internal.$${BRANCH_ENV}.homeoffice.gov.uk
       - export CUCUMBER_PUBLISH_ENABLED=true
       - npx playwright install

--- a/apps/end-tenancy/models/upload-pdf.js
+++ b/apps/end-tenancy/models/upload-pdf.js
@@ -38,6 +38,7 @@ module.exports = class UploadPDF {
       locals = this.sortSections(locs);
     }
 
+    locals.title = this.generatePDFTitle(req.sessionModel.get('what'));
     locals.dateTime = moment().format(config.dateTimeFormat);
     locals.values = req.sessionModel.toJSON();
     locals.htmlLang = res.locals.htmlLang || 'en';
@@ -78,12 +79,27 @@ module.exports = class UploadPDF {
     }
   }
 
+  generatePDFTitle(route) {
+    const translations = require('../../end-tenancy/translations/src/en/pages.json');
+
+    switch (route) {
+      case 'request':
+        return translations.pdf.header.request;
+      case 'check':
+        return translations.pdf.header.check;
+      case 'report':
+        return translations.pdf.header.report;
+      default:
+        return translations.pdf.header.default;
+    }
+  }
+
   sortSections(locals) {
     const translations = require('../../end-tenancy/translations/src/en/pages.json');
-    const sectionHeaders = Object.values(translations.confirm.sections);
+    const sectionHeaders = Object.values(translations.pdf.sections);
     const orderedSections = _.map(sectionHeaders, obj => obj.header);
-    let rows = locals.rows;
 
+    let rows = locals.rows;
     rows = rows.slice().sort((a, b) => orderedSections.indexOf(a.section) - orderedSections.indexOf(b.section));
 
     locals.rows = rows;

--- a/apps/end-tenancy/translations/src/en/fields.json
+++ b/apps/end-tenancy/translations/src/en/fields.json
@@ -62,7 +62,7 @@
       },
       "default": "Full name as it’s written on the Notice of Letting to a Disqualified Person"
     },
-    "summary": "Name"
+    "summary": "Name of Tenant"
   },
   "date-left": {
     "legend": "When did the tenant leave?",

--- a/apps/end-tenancy/translations/src/en/pages.json
+++ b/apps/end-tenancy/translations/src/en/pages.json
@@ -176,5 +176,33 @@
         "Friday 9am to 4:30pm"
       ]
     }
+  },
+  "pdf": {
+    "header": {
+      "report": "Report Application",
+      "check": "Check Application",
+      "request": "Request Application",
+      "default": "End Tenancy Application"
+    },
+    "sections": {
+      "key-details": {
+        "header": "Key details"
+      },
+      "tenants-left": {
+        "header": "Tenants who have left"
+      },
+      "tenants-request": {
+        "header": "Notice requested for"
+      },
+      "tenants-check": {
+        "header": "Tenants you are checking"
+      },
+      "landlord-details": {
+        "header": "Landlord details"
+      },
+      "agent-details": {
+        "header": "Agent details"
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
   },
   "dependencies": {
     "debug": "^4.3.2",
-    "hof": "^19.13.10",
+    "hof": "^19.14.9",
     "hogan.js": "^3.0.2",
     "is-pdf": "^1.0.0",
     "jquery": "^3.6.0",
     "lodash": "^4.17.21",
     "mixwith": "^0.1.1",
-    "moment": "^2.29.1",
+    "moment": "^2.29.3",
     "notifications-node-client": "^5.1.0",
     "typeahead-aria": "^1.0.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2984,10 +2984,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^19.13.10:
-  version "19.13.10"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-19.13.10.tgz#802c75c982d5cd12f528216cf106c740ce45861b"
-  integrity sha512-mimnsGabkQUaFATKhABs5p8np7c5twX8/rAwcr6fMn+inKOpsQxHoMM+J9ZHcciw8SDBxWiyGdKIx6Joki64Jg==
+hof@^19.14.9:
+  version "19.14.9"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-19.14.9.tgz#1af334b69082628c7ff1e4c43d12c2793a529da8"
+  integrity sha512-hsBsFHjGQnH2qbfwDd6Dt4x7z5BtWMN40J+gkX0Nm2Wx0RPj7FG8qz7UA7yhXV2/Tr0BzY4lZjKXWlVEbGxg3A==
   dependencies:
     aliasify "^2.1.0"
     bluebird "^3.7.2"
@@ -3023,10 +3023,9 @@ hof@^19.13.10:
     lodash "^4.17.21"
     markdown-it "^12.3.2"
     minimatch "^3.0.3"
-    minimist "^1.2.0"
+    minimist "^1.2.6"
     mixwith "^0.1.1"
-    mkdirp "^0.5.1"
-    moment "^2.24.0"
+    moment "^2.29.2"
     morgan "^1.10.0"
     mustache "^2.3.0"
     nodemailer "^6.6.3"
@@ -3041,8 +3040,8 @@ hof@^19.13.10:
     serve-static "^1.14.1"
     uglify-js "^3.14.3"
     underscore "^1.12.1"
-    urijs "^1.19.10"
-    winston "^3.3.3"
+    urijs "^1.19.11"
+    winston "^3.7.2"
 
 hogan-express-strict@^0.5.4:
   version "0.5.4"
@@ -4008,6 +4007,11 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
 mixwith@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/mixwith/-/mixwith-0.1.1.tgz#c8995918c5b61fbfda9ad377a857cd47750541c0"
@@ -4086,10 +4090,10 @@ module-not-found-error@^1.0.1:
   resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
   integrity sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=
 
-moment@^2.24.0, moment@^2.29.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+moment@^2.29.2, moment@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
+  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
 
 morgan@^1.10.0:
   version "1.10.0"
@@ -5834,10 +5838,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-urijs@^1.19.10:
-  version "1.19.10"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.10.tgz#8e2fe70a8192845c180f75074884278f1eea26cb"
-  integrity sha512-EzauQlgKuJgsXOqoMrCiePBf4At5jVqRhXykF3Wfb8ZsOBMxPcfiVBcsHXug4Aepb/ICm2PIgqAUGMelgdrWEg==
+urijs@^1.19.11:
+  version "1.19.11"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.11.tgz#204b0d6b605ae80bea54bea39280cdb7c9f923cc"
+  integrity sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==
 
 url@0.10.3:
   version "0.10.3"
@@ -5981,10 +5985,10 @@ winston-transport@^4.5.0:
     readable-stream "^3.6.0"
     triple-beam "^1.3.0"
 
-winston@^3.3.3:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.6.0.tgz#be32587a099a292b88c49fac6fa529d478d93fb6"
-  integrity sha512-9j8T75p+bcN6D00sF/zjFVmPp+t8KMPB1MzbbzYjeN9VWxdsYnTB40TkbNUEXAmILEfChMvAMgidlX64OG3p6w==
+winston@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.7.2.tgz#95b4eeddbec902b3db1424932ac634f887c400b1"
+  integrity sha512-QziIqtojHBoyzUOdQvQiar1DH0Xp9nF1A1y7NVy2DGEsz82SBDtOalS0ulTRGVT14xPX3WRWkCsdcJKqNflKng==
   dependencies:
     "@dabh/diagnostics" "^2.0.2"
     async "^3.2.3"


### PR DESCRIPTION
**Changes**

Stakeholders requested the PDF's become more uniformed in appearance across the 3 routes in end tenancy. 
Titles changed on the PDF's to reflect the type of application the users are making.

 **Code changes**

- Upgraded HOF to 19.14.9
- Added translation for branch name URLs in test_acceptance_branch steps in drone.yaml file
- Added new title generator depending on route to upload-pdf.js
- Changed Name to Name of Tenant in fields.json
- pages.json updated with new PDF Headers for each route.
- upload-pdf.spec updated with unit tests for all PDF's and sorting logic tests
- moment updated to 2.29.3 in package.json