### PR TITLE
Update to Node v18

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ trigger:
 
 linting: &linting
   pull: if-not-exists
-  image: node:14
+  image: node:18
   environment:
     NOTIFY_KEY: USE_MOCK
   commands:
@@ -33,7 +33,7 @@ linting: &linting
 
 unit_tests: &unit_tests
   pull: if-not-exists
-  image: node:14
+  image: node:18
   environment:
     NOTIFY_KEY: USE_MOCK
   commands:
@@ -67,7 +67,7 @@ steps:
 
   - name: setup_deploy
     pull: if-not-exists
-    image: node:14
+    image: node:18
     environment:
       NOTIFY_KEY: USE_MOCK
     commands:
@@ -176,7 +176,7 @@ steps:
 
   - name: setup_branch
     pull: if-not-exists
-    image: node:14
+    image: node:18
     environment:
       NOTIFY_KEY: USE_MOCK
     commands:
@@ -233,7 +233,7 @@ steps:
   # Snyk & Anchore security scans which run after branch deployment to prevent blocking of PR UAT tests
   - name: snyk_scan
     pull: if-not-exists
-    image: node:14
+    image: node:18
     environment:
       SNYK_TOKEN:
         from_secret: snyk_token
@@ -420,7 +420,7 @@ steps:
 
   - name: cron_snyk_scan
     pull: if-not-exists
-    image: node:14
+    image: node:18
     environment:
       SNYK_TOKEN:
         from_secret: snyk_token

--- a/.snyk
+++ b/.snyk
@@ -26,9 +26,9 @@ ignore:
   SNYK-JS-SHELLQUOTE-1766506:
     - hof > browserify > shell-quote:
         reason: Cannot update browserify
-        expires: '2021-12-18T15:02:19.415Z'
+        expires: '2023-12-18T15:02:19.415Z'
   SNYK-JS-JSONSCHEMA-1920922:
     - hof > request > http-signature > jsprim > json-schema:
         reason: Need to replace request
-        expires: '2021-12-18T15:02:19.416Z'
+        expires: '2023-12-18T15:02:19.416Z'
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -5,16 +5,16 @@ ignore:
   SNYK-JS-MINIMIST-2429795:
     - hof > browserify > module-deps > detective > minimist:
       reason: Cannot update browserify, latest version is 17.0.0
-      expires: '2022-10-26T11:10:21.865Z'
+      expires: '2023-10-26T11:10:21.865Z'
     - hof > browserify > module-deps > subarg > minimist:
       reason: Cannot update browserify, latest version is 17.0.0
-      expires: '2022-10-26T11:10:21.865Z'
+      expires: '2023-10-26T11:10:21.865Z'
     - hof > browserify > deps-sort > subarg > minimist:
       reason: Cannot update browserify, latest version is 17.0.0
-      expires: '2022-10-26T11:10:21.865Z'
+      expires: '2023-10-26T11:10:21.865Z'
     - hof > browserify > subarg > minimist:
       reason: Cannot update browserify, latest version is 17.0.0
-      expires: '2022-10-26T11:10:21.865Z'
+      expires: '2023-10-26T11:10:21.865Z'
   SNYK-JS-USERAGENT-174737:
     - device > useragent:
         reason: No available patch currently in circulation
@@ -22,7 +22,7 @@ ignore:
   SNYK-JS-REQUEST-1314897:
     - hof > request:
         reason: Need to replace request in HOF
-        expires: '2022-09-18T14:58:46.388Z'
+        expires: '2023-09-18T14:58:46.388Z'
   SNYK-JS-SHELLQUOTE-1766506:
     - hof > browserify > shell-quote:
         reason: Cannot update browserify

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:14-alpine@sha256:5c33bc6f021453ae2e393e6e20650a4df0a4737b1882d389f17069dc1933fdc5
+FROM node:18-alpine@sha256:2322b1bb3917b313f2e9308395aa5c39d51b91cc92a5d4d5be6d0451fcfb4d24
 
 USER root
 
 # Update packages as a result of Anchore security vulnerability checks
 RUN apk update && \
-    apk add --upgrade gnutls binutils nodejs nodejs-npm apk-tools libjpeg-turbo libcurl libx11 libxml2
+    apk add --upgrade gnutls binutils nodejs npm apk-tools libjpeg-turbo libcurl libx11 libxml2
 
 # Setup nodejs group & nodejs user
 RUN addgroup --system nodejs --gid 998 && \

--- a/Dockerfile-acceptance
+++ b/Dockerfile-acceptance
@@ -1,10 +1,10 @@
-FROM node:14-alpine@sha256:5c33bc6f021453ae2e393e6e20650a4df0a4737b1882d389f17069dc1933fdc5
+FROM node:18-alpine@sha256:2322b1bb3917b313f2e9308395aa5c39d51b91cc92a5d4d5be6d0451fcfb4d24
 
 USER root
 
 # Update packages as a result of Anchore security vulnerability checks
 RUN apk update && \
-    apk add --upgrade gnutls binutils nodejs nodejs-npm apk-tools libjpeg-turbo libcurl libx11 libxml2
+    apk add --upgrade gnutls binutils nodejs npm apk-tools libjpeg-turbo libcurl libx11 libxml2
 
 # Setup nodejs group & nodejs user
 RUN addgroup --system nodejs --gid 998 && \

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/UKHomeOffice/end-tenancy"
   },
   "engines": {
-    "node": "^14.15.0"
+    "node": "^18.12.1"
   },
   "license": "./LICENSE",
   "readme": "./README.md",


### PR DESCRIPTION
## What?
Update project to Node version 18. see jira ticket #UKVIET-55.
https://collaboration.homeoffice.gov.uk/jira/browse/UKVIET-55
## Why?
Part of Epic to upgrade all HOF services to Node v18. see jira ticket #HOFF-312
https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-312
## How?
- Updated node engine inside package.json from 14.15.0 to 18.12.1
- Updated main docker image to node:18-alpine
- Changed all references to node:14 in drone.yml to node:18
## Testing?
- All unit tests + acceptance tests pass
- Requires testing from QAT team
## Screenshots (optional)
## Anything Else?