### PR TITLE
WIP -DO NOT MERGE - HOFF-615: Replace Anchore with Trivy

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -129,6 +129,26 @@ steps:
       branch: master
       event: [push, pull_request]
 
+  # Trivy Security Scannner
+  - name: scan-image
+    pull: always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    resources:
+      limits:
+        cpu: 1000
+        memory: 1024Mi
+    environment:
+      IMAGE_NAME: end-tenancy:${DRONE_COMMIT_SHA}
+      SEVERITY: MEDIUM,HIGH,CRITICAL
+      FAIL_ON_DETECTION: false
+      IGNORE_UNFIXED: true
+      ALLOW_CVE_LIST_FILE: hof-services-config/UKVI_End_Tenancy/trivy-cve-exceptions.txt
+    when:
+      event:
+      - pull_request
+      - push
+      - tag
+
   # Deploy to pull request UAT environment
   - name: deploy_to_branch
     pull: if-not-exists
@@ -230,7 +250,7 @@ steps:
       branch: master
       event: pull_request
 
-  # Snyk & Anchore security scans which run after branch deployment to prevent blocking of PR UAT tests
+  # Snyk security scans which run after branch deployment to prevent blocking of PR UAT tests
   - name: snyk_scan
     pull: if-not-exists
     image: node:lts
@@ -244,18 +264,6 @@ steps:
         include:
           - master
           - feature/*
-      event: pull_request
-
-  - name: anchore_scan
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
-    pull: always
-    environment:
-      IMAGE_NAME: end-tenancy:${DRONE_COMMIT_SHA}
-      LOCAL_IMAGE: true
-      TOLERATE: medium
-      WHITELIST_FILE: hof-services-config/UKVI_End_Tenancy/anchore-cve-exceptions.txt
-    when:
-      branch: master
       event: pull_request
 
   # Deploy to Master UAT environment
@@ -393,7 +401,7 @@ steps:
       cron: tear_down_pr_envs
       event: cron
 
-  # CRON job steps that runs security scans using Snyk & Anchore
+  # CRON job steps that runs security scans using Snyk & Trivy
   - name: cron_clone_repos
     image: alpine/git
     environment:
@@ -432,14 +440,15 @@ steps:
       cron: security_scans
       event: cron
 
-  - name: cron_anchore_scan
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
+  - name: cron_trivy_scan
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
     pull: always
     environment:
       IMAGE_NAME: end-tenancy:${DRONE_COMMIT_SHA}
-      LOCAL_IMAGE: true
-      TOLERATE: medium
-      WHITELIST_FILE: hof-services-config/UKVI_End_Tenancy/anchore-cve-exceptions.txt
+      SEVERITY: MEDIUM,HIGH,CRITICAL
+      FAIL_ON_DETECTION: false
+      IGNORE_UNFIXED: true
+      ALLOW_CVE_LIST_FILE: hof-services-config/UKVI_End_Tenancy/trivy-cve-exceptions.txt
     when:
       cron: security_scans
       event: cron
@@ -482,13 +491,6 @@ steps:
 services:
   - name: docker
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-
-  # Anchore scanning needs background service to run
-  - name: anchore-submission-server
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
-    pull: always
-    commands:
-      - /run.sh server
 
   # Redis session setup in background so integration tests can run
   - name: session

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM node:lts-alpine@sha256:19eaf41f3b8c2ac2f609ac8103f9246a6a6d46716cdbe49103fd
 
 USER root
 
-# Update packages as a result of Anchore security vulnerability checks
 RUN apk update && \
     apk add --upgrade gnutls binutils nodejs apk-tools libjpeg-turbo libcurl libx11 libxml2
 


### PR DESCRIPTION
What?
 I've added Trivy Scanner to Pipeline and removed deprecated Anchore Scanner for the UKVI end tenancy service, see ticket
[https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-615](url)

Why?
Trivy will let you scan images, file systems and repositories for any vulnerabilities and issues. It will detect CVEs of OS packages, applications susceptibilities, and exposures of IaC in Terraform files, Kubernetes and Docker. Drawback of Anchore Scanner is it’s significantly slower, the process of using it is more cumbersome, the output is less friendly and most importantly, it scans fewer CVEs. 

How?
 Removed Anchore cve exception file and added trivy cve exception file in hof-services-config repo from UKVI end tenancy configs. Removed Anchore Scanner steps from pipeline and added trivy scanner steps with cron scanner. Our Acceptance criteria is to list the Medium to Critical vulnerabilities.

Testing?
We can test it by raising pull request to Master branch. Drone Pipeline should run through the steps and should list the Medium to Critical Vulnerabilties and should progress to next steps of deployment to branch
[https://drone-gh.acp.homeoffice.gov.uk/UKHomeOffice/end-tenancy/1178](url)

Screenshots This screenshot is from Drone CI console
![image](https://github.com/UKHomeOffice/end-tenancy/assets/146218064/26044a7d-6ff1-4ec3-8598-1a5682124147)
