### PR TITLE
UKVIET-75: Update UAT acceptance test url

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -264,7 +264,7 @@ steps:
   - name: test_acceptance_uat
     <<: *acceptance_tests
     commands:
-      - export ACCEPTANCE_HOST_NAME=https://dev.notprod.ending-a-tenancy.homeoffice.gov.uk
+      - export ACCEPTANCE_HOST_NAME=https://$${APP_NAME}.uat.internal.sas-notprod.homeoffice.gov.uk
       - export CUCUMBER_PUBLISH_ENABLED=true
       - npx playwright install
       - npm run test:acceptance


### PR DESCRIPTION
## What?
- Update UAT acceptance test url in drone.yml - [UKVIET-75](https://collaboration.homeoffice.gov.uk/jira/browse/UKVIET-75)
## Why?
- The uat url for UKVIET was changed but the url was not updated for the uat acceptance tests in drone.yml causing the uat acceptance tests to timeout in the drone build.
## How?
- Update UAT acceptance test host name in drone.yml
## Testing?
- can only be tested in merge build
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
