### PR TITLE
HOFF-927 filevault-upgrade

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -2,17 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  # {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  # annotations:
-  #   downscaler/uptime: {{ .NON_PROD_AVAILABILITY }}
-  # name: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-  # {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-  # annotations:
-  #   downscaler/uptime: {{ .NON_PROD_AVAILABILITY }}
-  # name: file-vault
-  # {{ else }}
-  # name: file-vault
-  # {{ end }}
   {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
   name: file-vault
   {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
@@ -52,7 +41,10 @@ spec:
     spec:
       containers:
         - name: file-vault
-          image: quay.io/ukhomeofficedigital/file-vault:bab000624c4323823cd4df723b44bc3bd29fec2c
+        # This is in relation to PR HOFF-403: Fix security vulnerabilities in file-vault
+        # https://github.com/UKHomeOffice/file-vault/pull/90/commits/8e8c7813936dc9a2d778e30dd8270c841308876e
+        # This is only for testing purposes in the branch
+          image: quay.io/ukhomeofficedigital/file-vault:8e8c7813936dc9a2d778e30dd8270c841308876e
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
## What?

Upgrade filevault in relation to the security updates
This is in relation PR HOFF-403: Fix security vulnerabilities in file-vault
https://github.com/UKHomeOffice/file-vault/pull/90/commits/8e8c7813936dc9a2d778e30dd8270c841308876e This is only for testing purposes in the branch

## Why?

There are security vulnerabilities that's why filevault has been updated

## Testing?

Manually tested by QAT

## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
