### PR TITLE
HOFF-963: Use latest keycloak proxy image

### DIFF
--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -96,22 +96,22 @@ spec:
             - name: KEYCLOAK_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: keycloak-form
+                  name: keycloak-user
                   key: username
             - name: KEYCLOAK_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: keycloak-form
+                  name: keycloak-user
                   key: password
             - name: KEYCLOAK_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: keycloak
+                  name: keycloak-client
                   key: id
             - name: KEYCLOAK_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: keycloak
+                  name: keycloak-client
                   key: secret
             - name: NOTIFY_KEY
               valueFrom:

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -52,7 +52,8 @@ spec:
     spec:
       containers:
         - name: file-vault
-          image: quay.io/ukhomeofficedigital/file-vault:bab000624c4323823cd4df723b44bc3bd29fec2c
+          # v3.0.1 28th August 2025
+          image: quay.io/ukhomeofficedigital/file-vault:3.0.1@sha256:44f35820701981eeb3371d332e6fd53f697e1bcd60f75731a57e8da6edb7bed5
           imagePullPolicy: Always
           resources:
             requests:
@@ -134,10 +135,10 @@ spec:
             runAsNonRoot: true
 
         - name: keycloak-proxy
-          image: quay.io/ukhomeofficedigital/go-keycloak-proxy:v2.2.2
+          image: quay.io/ukhomeofficedigital/gogatekeeper:3.5.0
           resources:
             limits:
-              memory: "1024Mi"
+              memory: 1024Mi
               cpu: 200m
           envFrom:
             - configMapRef:
@@ -150,12 +151,12 @@ spec:
             - name: PROXY_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: keycloak
+                  name: keycloak-client
                   key: secret
             - name: PROXY_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: keycloak
+                  name: keycloak-client
                   key: id
             - name: PROXY_LISTEN
               value: 127.0.0.1:3001
@@ -171,25 +172,31 @@ spec:
             {{ end }}
             - name: PROXY_UPSTREAM_URL
               value: "http://127.0.0.1:3000"
-          command:
-            - "/opt/keycloak-proxy"
-            - "--resources=uri=/file|methods=GET,POST|roles=caseworkers"
-            - "--resources=uri=/*"
-            - "--enable-logging=true"
-            - "--enable-json-logging=true"
+          args:
+            # URls that you wish to protect.
+            - --resources=uri=/*
+            - --enable-default-deny=false
+            - --enable-security-filter=true
+            - --enable-request-id=true
+            - --enable-logging=true
+            - --enable-json-logging=true
+            - --enable-encrypted-token=false
+          {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+            - --verbose=true
+          {{ end }}
           securityContext:
             runAsNonRoot: true
+
 
         - name: nginx-proxy
           # nginx-proxy-govuk:v4
           image: quay.io/ukhomeofficedigital/nginx-proxy-govuk@sha256:4470064d0b1d20ae08c5fd85551576cb687f342a22d6cb456fda9b2c4ce8c8df
           resources:
             limits:
-              cpu: 250m
-              memory: 256Mi
+              memory: 1024Mi
+              cpu: 200m
             requests:
-              cpu: 10m
-              memory: 10Mi
+              memory: 512Mi
           env:
 {{ file .FILEVAULT_NGINX_SETTINGS | indent 12 }}
           ports:


### PR DESCRIPTION
## What?

- Updated the keycloak-proxy image for Keycloak v22 compatibility and vulnerability fixes.
- Updated the file-vault image to address security issues.
- We have already created (keycloak-user and keycloak-client) secrets in branch, uat and stage envs.
- This work covers [HOFF-963](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-963) and [HOFF-964](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-964)

## Why?

- To ensure compatibility with Keycloak v22.
- To enhance security by fixing vulnerabilities in both keycloak-proxy and file-vault images.
- Lamp is using both these images.

## How?

- Upgraded the keycloak-proxy image to the latest version supporting Keycloak v22.
- Applied security patches to both images.
- Verified authentication flow and proxy protection.
- Ran security scans to confirm vulnerabilities are resolved.
- Additionally updated Keycloak End points in hof-services-config and updated keycloak-client and keycloak-secrets in namespaces


## Testing?

Branch Testing done. Now We want to merge to Master to test in UAT and Stage.


## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
