### PR TITLE
HOFF-1916: Add Github Actions for Scanning Vulnerabilities

### DIFF
--- a/.github/workflows/scan-for-evil-packages.yml
+++ b/.github/workflows/scan-for-evil-packages.yml
@@ -1,0 +1,14 @@
+name: Scan for Evil Packages
+
+on:
+  repository_dispatch:
+    types: [trigger-from-scanmaestro]
+
+jobs:
+  scan:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Run Scan for Evil Packages
+        uses: UKHomeOffice/hof-maestro-scanner/.github/actions/scan-for-evil-packages@main
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## What?
Added GitHub actions to scan dependency packages
Relates to HOFF-1916 (https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-1916)
UKVI End Tenancy: Create Github Action for Scanning
## Why?
## How?
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging