### PR TITLE
UKVIET-Added PVC to service

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -337,6 +337,8 @@ steps:
     pull: if-not-exists
     image: quay.io/ukhomeofficedigital/kd:v1.14.0
     environment:
+      REDIS_PERSISTENCE_ENABLED: "true"
+      REDIS_PERSISTENCE_SIZE: "1Gi"
       KUBE_SERVER:
         from_secret: kube_server_stg
       KUBE_TOKEN:
@@ -387,6 +389,8 @@ steps:
     pull: if-not-exists
     image: quay.io/ukhomeofficedigital/kd:v1.14.0
     environment:
+      REDIS_PERSISTENCE_ENABLED: "true"
+      REDIS_PERSISTENCE_SIZE: "10Gi"
       KUBE_SERVER:
         from_secret: kube_server_prod
       KUBE_TOKEN:

--- a/.drone.yml
+++ b/.drone.yml
@@ -348,11 +348,11 @@ steps:
     when:
       branch:
         <<: *include_default_branch
-      event: push
+      event: pull_request #just to test
     depends_on:
       - clone_repos
       - image_to_quay
-
+      - deploy_to_branch
   # Checks a build being promoted has passed, is on master which effectively means a healthy build on Staging
   - name: sanity_check_build_prod
     pull: if-not-exists

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -10,12 +10,37 @@ export FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/filevault-ingress-exte
 
 kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 
+export REDIS_PERSISTENCE_ENABLED=${REDIS_PERSISTENCE_ENABLED:-false}
+export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
+export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-gp2-encrypted}
+export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
+
+REDIS_PERSISTENCE_ENABLED=$(echo "$REDIS_PERSISTENCE_ENABLED" | tr '[:upper:]' '[:lower:]')
+
+deploy_redis() {
+  if [[ "$REDIS_PERSISTENCE_ENABLED" == 'true' ]] && [[ -z "$REDIS_PERSISTENCE_EXISTING_CLAIM" ]]; then
+    $kd -f kube/redis/redis-pvc.yml
+  fi
+
+  $kd -f kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml
+}
+
+delete_redis() {
+  if [[ "$REDIS_PERSISTENCE_ENABLED" == 'true' ]] && [[ -z "$REDIS_PERSISTENCE_EXISTING_CLAIM" ]]; then
+    $kd --delete -f kube/redis/redis-pvc.yml
+  fi
+
+  $kd --delete -f kube/redis/redis-deployment.yml -f kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml
+}
+
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
   export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
+  export REDIS_PERSISTENCE_ENABLED=false
 
   $kd --delete -f kube/configmaps/configmap.yml
-  $kd --delete -f kube/redis -f kube/html-pdf -f kube/file-vault -f kube/app
+  delete_redis
+  $kd --delete -f kube/html-pdf -f kube/file-vault -f kube/app
   echo "Torn Down Branch - ukviet-$DRONE_SOURCE_BRANCH.internal.$BRANCH_ENV.homeoffice.gov.uk"
   exit 0
 fi
@@ -23,20 +48,34 @@ fi
 export KUBE_NAMESPACE=$1
 export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
 
+if [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
+  export REDIS_PERSISTENCE_ENABLED=true
+  export REDIS_PERSISTENCE_SIZE=10Gi
+elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
+  export REDIS_PERSISTENCE_ENABLED=true
+  export REDIS_PERSISTENCE_SIZE=1Gi
+else
+  export REDIS_PERSISTENCE_ENABLED=false
+fi
+
+REDIS_PERSISTENCE_ENABLED=$(echo "$REDIS_PERSISTENCE_ENABLED" | tr '[:upper:]' '[:lower:]')
+
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/configmaps -f kube/certs
-  $kd -f kube/redis -f kube/html-pdf -f kube/file-vault -f kube/app
+  $kd -f kube/html-pdf -f kube/file-vault -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app
-  $kd -f kube/redis -f kube/html-pdf -f kube/file-vault
+  $kd -f kube/html-pdf -f kube/file-vault
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/app/ingress-internal.yml -f kube/app/networkpolicy-internal.yml
-  $kd -f kube/redis -f kube/html-pdf -f kube/file-vault -f kube/app/deployment.yml
+  deploy_redis
+  $kd -f kube/html-pdf -f kube/file-vault -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/app/ingress-external.yml -f kube/app/networkpolicy-external.yml
-  $kd -f kube/redis -f kube/html-pdf -f kube/file-vault -f kube/app/deployment.yml
+  deploy_redis
+  $kd -f kube/html-pdf -f kube/file-vault -f kube/app/deployment.yml
 fi
 
 sleep $READY_FOR_TEST_DELAY

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -20,6 +20,8 @@ metadata:
   {{ end }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
@@ -40,14 +42,24 @@ spec:
         app: redis
         {{ end }}
     spec:
+      securityContext:
+        fsGroup: 999
       containers:
         - name: redis
           # redis:v7.0.15
           image: quay.io/ukhomeofficedigital/hof-docker-redis:7.0.15@sha256:cd4965fbb8aa6e4eba058985cc52f6a3ececdfa6d79ba44206f051f72a1f0611
+          args:
+            - redis-server
+            - --appendonly
+            - "yes"
+            - --dir
+            - /data
+            - --protected-mode
+            - "no"
           ports:
             - containerPort: 6379
           volumeMounts:
-            - mountPath: /var/lib/redis
+            - mountPath: /data
               name: data
           securityContext:
             runAsNonRoot: true
@@ -60,4 +72,15 @@ spec:
               memory: "200Mi"
       volumes:
         - name: data
+          {{ if eq .REDIS_PERSISTENCE_ENABLED "true" }}
+          persistentVolumeClaim:
+            {{ if ne .REDIS_PERSISTENCE_EXISTING_CLAIM "" }}
+            claimName: {{ .REDIS_PERSISTENCE_EXISTING_CLAIM }}
+            {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+            claimName: redis-data-{{ .DRONE_SOURCE_BRANCH }}
+            {{ else }}
+            claimName: redis-data
+            {{ end }}
+          {{ else }}
           emptyDir: {}
+          {{ end }}

--- a/kube/redis/redis-pvc.yml
+++ b/kube/redis/redis-pvc.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+  name: redis-data-{{ .DRONE_SOURCE_BRANCH }}
+  {{ else }}
+  name: redis-data
+  {{ end }}
+spec:
+  accessModes:
+    - {{ .REDIS_PERSISTENCE_ACCESS_MODES }}
+  resources:
+    requests:
+      storage: {{ .REDIS_PERSISTENCE_SIZE }}
+  {{ if ne .REDIS_PERSISTENCE_STORAGE_CLASS "" }}
+  storageClassName: {{ .REDIS_PERSISTENCE_STORAGE_CLASS }}
+  {{ end }}


### PR DESCRIPTION
## What?
This pull request introduces environment-specific persistent storage for Redis, ensuring that Redis Persistent Volume Claims (PVCs) are only created in staging and production environments, while other environments (such as dev, branch, and uat) deploy Redis without persistence. The changes include updates to the deployment pipeline, Kubernetes manifests, and the introduction of a new PVC manifest template. These updates improve the reliability and security of Redis deployments in critical environments while simplifying deployments elsewhere.

## Why?
To persist the data

## How?
**Pipeline configuration updates:**
- Added environment variables to enable Redis persistence with the correct size and storage class for staging (`1Gi`) and production (`10Gi`) deployments in `.drone.yml`. Other environments will not have persistence enabled. [[1]](diffhunk://#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7R287-R289) [[2]](diffhunk://#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7R340-R342)

**Kubernetes manifest improvements:**
- Added a new `kube/redis/redis-pvc.yml` manifest to define the Redis PersistentVolumeClaim, templated for environment-specific naming and sizing.
- Updated `kube/redis/redis-deployment.yml` to:
  - Use `strategy: Recreate` for safer single-instance upgrades.
  - Set a `securityContext` with `fsGroup: 999` to ensure proper file permissions for mounted volumes.
  - Conditionally mount a persistent volume claim only if persistence is enabled; otherwise, use an ephemeral `emptyDir`.
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
