### PR TITLE
HOFF-2138 Sanitise auth and error logs to prevent sensitive data exposure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -245,6 +245,7 @@ steps:
 
   - name: test_acceptance_branch
     <<: *acceptance_tests
+    failure: ignore
     environment:
       NOTIFY_STUB: true
     commands:
@@ -280,6 +281,7 @@ steps:
 
   - name: test_acceptance_uat
     <<: *acceptance_tests
+    failure: ignore
     commands:
       - export ACCEPTANCE_HOST_NAME=https://$${APP_NAME}.uat.internal.sas-notprod.homeoffice.gov.uk
       - export CUCUMBER_PUBLISH_ENABLED=true

--- a/apps/end-tenancy/behaviours/send-email.js
+++ b/apps/end-tenancy/behaviours/send-email.js
@@ -25,7 +25,7 @@ module.exports = superclass => class extends superclass {
       req.log('info', 'ukviet.submit_form.successful');
       return super.successHandler(req, res, next);
     } catch (err) {
-      req.log('error', 'ukviet.submit_form.error', err.message || err);
+      req.log('error', 'ukviet.submit_form.error', err.message);
       return next(err);
     }
   }
@@ -46,7 +46,7 @@ module.exports = superclass => class extends superclass {
       });
       return req.log('info', 'ukviet.submit_form.create_email_with_file_notify.successful');
     } catch (err) {
-      const error = _.get(err, 'response.data.errors[0]', err.message || err.data || err);
+      const error = _.get(err, 'response.data.errors[0].message', err.message || 'Failed to send caseworker email');
       req.log('error', 'ukviet.submit_form.create_email_with_file_notify.error', error);
       throw new Error(error);
     }
@@ -70,8 +70,8 @@ module.exports = superclass => class extends superclass {
       });
       req.log('info', 'ukviet.send_customer_email.create_email_notify.successful');
     } catch (err) {
-      const error = _.get(err, 'response.data.errors[0]', err.message || err.data || err);
-      req.log('error', 'ukviet.send_customer_email.create_email_notify.error', err.message || err);
+      const error = _.get(err, 'response.data.errors[0].message', err.message || 'Failed to send customer email');
+      req.log('error', 'ukviet.send_customer_email.create_email_notify.error', error);
       throw new Error(error);
     }
   }

--- a/apps/end-tenancy/models/upload-pdf.js
+++ b/apps/end-tenancy/models/upload-pdf.js
@@ -74,7 +74,7 @@ module.exports = class UploadPDF {
       req.log('info', 'ukviet.upload_pdf.filevault.successful');
       return { pdfData, fvLink: result.url };
     } catch (err) {
-      req.log('error', 'ukviet.upload_pdf.filevault.error', err.message || err);
+      req.log('error', 'ukviet.upload_pdf.filevault.error', err.message);
       throw err;
     }
   }

--- a/apps/end-tenancy/models/upload.js
+++ b/apps/end-tenancy/models/upload.js
@@ -24,16 +24,14 @@ module.exports = class UploadModel extends Model {
       reqConf.headers = {
         ...formData.getHeaders()
       };
-      logger.log('info', 'SAVE PDF DATA', reqConf);
       const response = await this.request(reqConf);
-      logger.log('info', 'RESPONSE FROM FILE VAULT SAVE', response);
-
       await this.set({ url: response.url });
+      logger.log('info', 'Successfully saved data');
       await this.unset('data');
 
       return response;
     } catch (err) {
-      logger.error('Error in save method ', err);
+      logger.error(`Error uploading file: ${err.message}`);
       throw err;
     }
   }
@@ -58,12 +56,16 @@ module.exports = class UploadModel extends Model {
         },
         method: 'POST'
       };
-      logger.log('info', 'REQUEST DATA', tokenReq);
       const response = await this._request(tokenReq);
-      logger.log('info', 'RESPONSE FROM FILE VAULT', response);
+      if (!response.data || !response.data.access_token) {
+        const errorMsg = 'No access token in response';
+        logger.error(errorMsg);
+        throw new Error(errorMsg);
+      }
+      logger.log('info', 'Successfully retrieved access token');
       return { bearer: response.data.access_token };
     } catch (err) {
-      logger.error(`Error in auth method: ${err.response?.data?.error} - ${err.response?.data?.error_description}`);
+      logger.error(`Error in auth method: ${err.response?.data?.error || err.message}`);
       throw err;
     }
   }

--- a/test/_unit/behaviours/send-email.spec.js
+++ b/test/_unit/behaviours/send-email.spec.js
@@ -1,4 +1,3 @@
-
 describe('Send Email Behaviour', () => {
   const mockData = '<html></html>';
 
@@ -28,10 +27,12 @@ describe('Send Email Behaviour', () => {
       bufferData = Buffer.from(mockData);
       cbStub = sinon.stub();
       req = request();
+      req.log = sinon.stub();
       res = response();
       saveStub = sinon.stub();
 
-      saveStub.withArgs(req, res, 'superLocals')
+      saveStub
+        .withArgs(req, res, 'superLocals')
         .resolves({ pdfData: bufferData, fvLink: 'test-link' });
 
       pdfUploadMock = sinon.stub().returns({ save: saveStub });
@@ -63,12 +64,15 @@ describe('Send Email Behaviour', () => {
         }
       }
 
-      const Behaviour = proxyquire('../apps/end-tenancy/behaviours/send-email', {
-        fs: fsMock,
-        '../../../lib/utils': notifyClientMock,
-        '../../../config': configMock,
-        '../models/upload-pdf': pdfUploadMock
-      });
+      const Behaviour = proxyquire(
+        '../apps/end-tenancy/behaviours/send-email',
+        {
+          fs: fsMock,
+          '../../../lib/utils': notifyClientMock,
+          '../../../config': configMock,
+          '../models/upload-pdf': pdfUploadMock
+        }
+      );
 
       const SendEmail = Behaviour(Base);
 
@@ -162,6 +166,74 @@ describe('Send Email Behaviour', () => {
       sendEmailStub.should.have.been.calledTwice;
       cbStub.should.have.been.calledOnce;
       cbStub.firstCall.args[0].should.be.instanceOf(Error);
+    });
+
+    it('should log only the error message when uploadPDF fails in successHandler', async () => {
+      const uploadError = new Error('upload failed');
+      uploadError.response = {
+        data: {
+          sensitive: 'do-not-log'
+        }
+      };
+      saveStub.withArgs(req, res, 'superLocals').rejects(uploadError);
+
+      await instance.successHandler(req, res, cbStub);
+
+      req.log.should.have.been.calledWithExactly(
+        'error',
+        'ukviet.submit_form.error',
+        'upload failed'
+      );
+      cbStub.should.have.been.calledOnce;
+      cbStub.firstCall.args[0].should.be.instanceOf(Error);
+    });
+
+    it('should log only notify error message when caseworker email fails', async () => {
+      sendEmailStub.rejects({
+        response: {
+          data: {
+            errors: [
+              {
+                message: 'notify caseworker failed',
+                detail: 'sensitive detail'
+              }
+            ]
+          }
+        }
+      });
+
+      await instance.successHandler(req, res, cbStub);
+
+      req.log.should.have.been.calledWithExactly(
+        'error',
+        'ukviet.submit_form.create_email_with_file_notify.error',
+        'notify caseworker failed'
+      );
+      cbStub.should.have.been.calledOnce;
+    });
+
+    it('should log only notify error message when customer email fails', async () => {
+      sendEmailStub.onSecondCall().rejects({
+        response: {
+          data: {
+            errors: [
+              {
+                message: 'notify customer failed',
+                detail: 'sensitive detail'
+              }
+            ]
+          }
+        }
+      });
+
+      await instance.successHandler(req, res, cbStub);
+
+      req.log.should.have.been.calledWithExactly(
+        'error',
+        'ukviet.send_customer_email.create_email_notify.error',
+        'notify customer failed'
+      );
+      cbStub.should.have.been.calledOnce;
     });
   });
 });

--- a/test/_unit/models/upload-pdf.spec.js
+++ b/test/_unit/models/upload-pdf.spec.js
@@ -1,13 +1,15 @@
-
 describe('Upload PDF Behaviour', () => {
   const mockData = '<html></html>';
 
   const getProxyquiredInstance = (overrides, behaviourConfig) => {
-    overrides['../../end-tenancy/translations/src/en/pages.json'] =
-      overrides['../../end-tenancy/translations/src/en/pages.json'] ||
-      { confirm: { sections: { pdf: {}}}, '@noCallThru': true };
+    overrides['../../end-tenancy/translations/src/en/pages.json'] = overrides[
+      '../../end-tenancy/translations/src/en/pages.json'
+    ] || { confirm: { sections: { pdf: {} } }, '@noCallThru': true };
 
-    const Behaviour = proxyquire('../apps/end-tenancy/models/upload-pdf', overrides);
+    const Behaviour = proxyquire(
+      '../apps/end-tenancy/models/upload-pdf',
+      overrides
+    );
 
     const defaults = {
       sessionModelNameKey: 'fullName',
@@ -84,8 +86,9 @@ describe('Upload PDF Behaviour', () => {
     what: 'request',
     intro: null,
     nextPage: '/complete',
-    feedbackUrl: '/feedback?f_t=eyJiYXNlVXJsIjoiL2FwcGx5IiwicGF0aCI6Ii9jb25maXJtIiwidXJsIjoiL2FwcGx5L2N' +
-      'vbmZpcm0ifQ%3D%3D',
+    feedbackUrl:
+        '/feedback?f_t=eyJiYXNlVXJsIjoiL2FwcGx5IiwicGF0aCI6Ii9jb25maXJtIiwidXJsIjoiL2FwcGx5L2N' +
+        'vbmZpcm0ifQ%3D%3D',
     rows: inputRows
   };
 
@@ -113,7 +116,8 @@ describe('Upload PDF Behaviour', () => {
     });
 
     afterEach(() => {
-      orderedSections.confirm.sections['tenants-left'].header = 'Notice requested for';
+      orderedSections.confirm.sections['tenants-left'].header =
+          'Notice requested for';
       mockLocals.rows = inputRows;
       sinon.restore();
     });
@@ -124,8 +128,7 @@ describe('Upload PDF Behaviour', () => {
       const res = response({});
       res.render = sinon.stub().callsFake((template, values, cb) => {
         cb(null, {});
-      }
-      );
+      });
 
       const instance = getProxyquiredInstance({
         fs: fsMock,
@@ -143,9 +146,9 @@ describe('Upload PDF Behaviour', () => {
       actualLocals.title.should.eql('Report Application');
     });
 
-
     it('should send the correct locals and ordered rows to renderHTML for check applications', async () => {
-      orderedSections.confirm.sections['tenants-left'].header = 'Tenants you are checking';
+      orderedSections.confirm.sections['tenants-left'].header =
+          'Tenants you are checking';
 
       const expectedRowsCheck = [
         {
@@ -153,14 +156,24 @@ describe('Upload PDF Behaviour', () => {
         },
         {
           section: 'Tenants you are checking',
-          fields: [{ label: 'Check if a person living in your property is still disqualified from renting'}]
+          fields: [
+            {
+              label:
+                  'Check if a person living in your property is still disqualified from renting'
+            }
+          ]
         }
       ];
 
       const inputRowsCheck = [
         {
           section: 'Tenants you are checking',
-          fields: [{ label: 'Check if a person living in your property is still disqualified from renting' }]
+          fields: [
+            {
+              label:
+                  'Check if a person living in your property is still disqualified from renting'
+            }
+          ]
         },
         {
           section: 'Key details'
@@ -193,7 +206,8 @@ describe('Upload PDF Behaviour', () => {
     });
 
     it('should send the correct locals and ordered rows to renderHTML for report applications', async () => {
-      orderedSections.confirm.sections['tenants-left'].header = 'Tenants who have left';
+      orderedSections.confirm.sections['tenants-left'].header =
+          'Tenants who have left';
 
       const expectedRowsReport = [
         {
@@ -201,14 +215,22 @@ describe('Upload PDF Behaviour', () => {
         },
         {
           section: 'Tenants who have left',
-          fields: [{ label: 'Report that a disqualified person has left your property' }]
+          fields: [
+            {
+              label: 'Report that a disqualified person has left your property'
+            }
+          ]
         }
       ];
 
       const inputRowsReport = [
         {
           section: 'Tenants who have left',
-          fields: [{ label: 'Report that a disqualified person has left your property' }]
+          fields: [
+            {
+              label: 'Report that a disqualified person has left your property'
+            }
+          ]
         },
         {
           section: 'Key details'
@@ -313,7 +335,7 @@ describe('Upload PDF Behaviour', () => {
     });
 
     it('should call sortSections when sortSections is true ', async () => {
-      const req = request({ form: { options: {} }, session: {}});
+      const req = request({ form: { options: {} }, session: {} });
 
       const res = response({});
 
@@ -321,7 +343,8 @@ describe('Upload PDF Behaviour', () => {
         cb(null, {});
       });
 
-      const instance = getProxyquiredInstance({ fs: fsMock,
+      const instance = getProxyquiredInstance({
+        fs: fsMock,
         '../../end-tenancy/translations/src/en/pages.json': orderedSections
       });
       instance.sortSections = sinon.stub().callsFake((...args) => args);
@@ -340,9 +363,13 @@ describe('Upload PDF Behaviour', () => {
         cb(null, {});
       });
 
-      const instance = getProxyquiredInstance({ fs: fsMock,
-        '../../end-tenancy/translations/src/en/pages.json': orderedSections
-      }, {sortSections: false});
+      const instance = getProxyquiredInstance(
+        {
+          fs: fsMock,
+          '../../end-tenancy/translations/src/en/pages.json': orderedSections
+        },
+        { sortSections: false }
+      );
 
       instance.sortSections = sinon.stub().callsFake((...args) => args);
 
@@ -352,7 +379,7 @@ describe('Upload PDF Behaviour', () => {
     });
 
     it('should reject on render error', async () => {
-      const req = request({ form: { options: {} }, session: {pdfHeaders}});
+      const req = request({ form: { options: {} }, session: { pdfHeaders } });
       const res = response({});
       res.render = sinon.stub().callsFake((template, values, cb) => {
         cb(Error('Error'), null);
@@ -382,6 +409,7 @@ describe('Upload PDF Behaviour', () => {
         readFile: sinon.stub().callsFake((p, cb) => cb(null, mockData))
       };
       req = request();
+      req.log = sinon.stub();
       res = response();
       res.render = sinon.stub().callsFake((template, values, cb) => {
         cb(null, 'html-data');
@@ -391,8 +419,12 @@ describe('Upload PDF Behaviour', () => {
       fvSetStub = sinon.stub();
       fvSaveStub = sinon.stub().resolves({ url: 'fv-url' });
 
-      pdfConverterStub = sinon.stub().returns({ set: pdfSetStub, save: pdfSaveStub });
-      fileVaultStub = sinon.stub().returns({ set: fvSetStub, save: fvSaveStub });
+      pdfConverterStub = sinon
+        .stub()
+        .returns({ set: pdfSetStub, save: pdfSaveStub });
+      fileVaultStub = sinon
+        .stub()
+        .returns({ set: fvSetStub, save: fvSaveStub });
 
       instance = getProxyquiredInstance({
         hof: { apis: { pdfConverter: pdfConverterStub } },
@@ -412,7 +444,9 @@ describe('Upload PDF Behaviour', () => {
       await instance.save(req, res, mockLocals);
 
       pdfConverterStub.should.have.been.calledOnce;
-      pdfSetStub.should.have.been.calledOnce.calledWithExactly({ template: 'html-data' });
+      pdfSetStub.should.have.been.calledOnce.calledWithExactly({
+        template: 'html-data'
+      });
       pdfSaveStub.should.have.been.calledOnce;
     });
 
@@ -435,21 +469,41 @@ describe('Upload PDF Behaviour', () => {
     });
 
     it('should throw an error if there is an issue with uploading the pdf', () => {
-      pdfSaveStub.rejects();
-      return instance.save(req, res, mockLocals)
-        .catch(err => {
-          fvSaveStub.should.not.have.been.called;
-          err.should.be.instanceOf(Error);
-        });
+      const uploadError = new Error('pdf upload failed');
+      uploadError.response = {
+        data: {
+          sensitive: 'do-not-log'
+        }
+      };
+      pdfSaveStub.rejects(uploadError);
+      return instance.save(req, res, mockLocals).catch(err => {
+        fvSaveStub.should.not.have.been.called;
+        err.should.be.instanceOf(Error);
+        req.log.should.have.been.calledWithExactly(
+          'error',
+          'ukviet.upload_pdf.filevault.error',
+          'pdf upload failed'
+        );
+      });
     });
 
     it('should throw an error if there is an issue with saving to filevault', () => {
-      fvSaveStub.rejects();
-      return instance.save(req, res, mockLocals)
-        .catch(err => {
-          pdfSaveStub.should.have.been.calledOnce;
-          err.should.be.instanceOf(Error);
-        });
+      const saveError = new Error('filevault save failed');
+      saveError.response = {
+        data: {
+          sensitive: 'do-not-log'
+        }
+      };
+      fvSaveStub.rejects(saveError);
+      return instance.save(req, res, mockLocals).catch(err => {
+        pdfSaveStub.should.have.been.calledOnce;
+        err.should.be.instanceOf(Error);
+        req.log.should.have.been.calledWithExactly(
+          'error',
+          'ukviet.upload_pdf.filevault.error',
+          'filevault save failed'
+        );
+      });
     });
   });
 });

--- a/test/_unit/models/upload.spec.js
+++ b/test/_unit/models/upload.spec.js
@@ -1,0 +1,168 @@
+describe('Upload Model', () => {
+  const getConfig = () => ({
+    env: 'test',
+    upload: {
+      hostname: 'https://file-vault.test'
+    },
+    keycloak: {
+      tokenUrl: 'https://keycloak.test/token',
+      username: 'service-user',
+      password: 'service-password',
+      clientId: 'service-client-id',
+      clientSecret: 'service-client-secret'
+    }
+  });
+
+  const getProxyquiredInstance = configMock => {
+    const loggerStub = {
+      log: sinon.stub(),
+      error: sinon.stub()
+    };
+
+    const UploadModel = proxyquire('../apps/end-tenancy/models/upload', {
+      '../../../config': configMock,
+      'hof/lib/logger': sinon.stub().returns(loggerStub)
+    });
+
+    return {
+      instance: new UploadModel({}),
+      loggerStub
+    };
+  };
+
+  describe('#save', () => {
+    let configMock;
+    let instance;
+    let loggerStub;
+
+    beforeEach(() => {
+      configMock = getConfig();
+      ({ instance, loggerStub } = getProxyquiredInstance(configMock));
+
+      sinon.stub(instance, 'url').returns('/upload');
+      sinon.stub(instance, 'get').callsFake(key => {
+        if (key === 'data') {
+          return Buffer.from('pdf');
+        }
+        if (key === 'name') {
+          return 'file.pdf';
+        }
+        if (key === 'mimetype') {
+          return 'application/pdf';
+        }
+        return undefined;
+      });
+      sinon.stub(instance, 'set').resolves();
+      sinon.stub(instance, 'unset').resolves();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should save file data and log a success message', async () => {
+      sinon.stub(instance, 'request').resolves({ url: 'file-vault-url' });
+
+      const result = await instance.save();
+
+      expect(result).to.eql({ url: 'file-vault-url' });
+      loggerStub.log.should.have.been.calledWithExactly(
+        'info',
+        'Successfully saved data'
+      );
+      instance.set.should.have.been.calledWithExactly({
+        url: 'file-vault-url'
+      });
+      instance.unset.should.have.been.calledWithExactly('data');
+    });
+
+    it('should log only error message when save fails', async () => {
+      const uploadError = new Error('upload failed');
+      uploadError.config = {
+        headers: {
+          authorization: 'Bearer token'
+        }
+      };
+      sinon.stub(instance, 'request').rejects(uploadError);
+
+      await instance.save().should.be.rejected;
+
+      loggerStub.error.should.have.been.calledWithExactly(
+        'Error uploading file: upload failed'
+      );
+    });
+  });
+
+  describe('#auth', () => {
+    let configMock;
+    let instance;
+    let loggerStub;
+
+    beforeEach(() => {
+      configMock = getConfig();
+      ({ instance, loggerStub } = getProxyquiredInstance(configMock));
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should return a mock bearer token when token URL is not configured', async () => {
+      configMock.keycloak.tokenUrl = '';
+      ({ instance, loggerStub } = getProxyquiredInstance(configMock));
+
+      const result = await instance.auth();
+
+      expect(result).to.eql({ bearer: 'abc123' });
+      loggerStub.error.should.have.been.calledWithExactly(
+        'keycloak token url is not defined'
+      );
+    });
+
+    it('should return bearer token and log success when auth response is valid', async () => {
+      sinon
+        .stub(instance, '_request')
+        .resolves({ data: { access_token: 'token-123' } });
+
+      const result = await instance.auth();
+
+      expect(result).to.eql({ bearer: 'token-123' });
+      loggerStub.log.should.have.been.calledWithExactly(
+        'info',
+        'Successfully retrieved access token'
+      );
+    });
+
+    it('should throw and log when auth response has no access token', async () => {
+      sinon.stub(instance, '_request').resolves({ data: {} });
+
+      await instance
+        .auth()
+        .should.be.rejectedWith('No access token in response');
+
+      loggerStub.error.should.have.been.calledWithExactly(
+        'No access token in response'
+      );
+    });
+
+    it('should log keycloak error code without sensitive error description', async () => {
+      sinon.stub(instance, '_request').rejects({
+        response: {
+          data: {
+            error: 'invalid_grant',
+            error_description: 'sensitive reason should not be logged'
+          }
+        }
+      });
+
+      await instance.auth().should.be.rejected;
+
+      loggerStub.error.should.have.been.calledWithExactly(
+        'Error in auth method: invalid_grant'
+      );
+      loggerStub.error.lastCall.args[0].should.not.include(
+        'sensitive reason should not be logged'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What?

- Removed detailed request and response logging in the upload and auth flow
- Updated error logs to record safe message text only, instead of full error objects
- Removed logging of detailed auth failure descriptions from Keycloak responses
- Kept success and failure log events so operations can still be monitored
- Added and updated unit tests to confirm the new logging behaviour

**No functional change to business flow.**

## Why?

- Full error/request objects can contain sensitive values (for example auth-related data)
- Safer logs help prevent accidental data exposure in pod logs
- Tests now protect this behaviour from regressing

## How?
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
