### PR TITLE
HOTFIX: Add back redis deployments to deploy scripts

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -12,32 +12,11 @@ export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWrit
 export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-gp2-encrypted}
 export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
 
-kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
-redis_storage_files='kube/redis/redis-persistent-volume-claim.yml'
+redis_storage_files='kube/redis/redis-persistent-volume.yml'
 redis_runtime_files='kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml'
 
-recreate_redis_pvc_if_image_changed() {
-  if [[ ${REDIS_PERSISTENCE_ENABLED} != true ]]; then
-    return
-  fi
+kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 
-  if [[ -n "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
-    return
-  fi
-
-  current_redis_image=$($kubectl get deployment redis -o jsonpath='{.spec.template.spec.containers[?(@.name=="redis")].image}' 2>/dev/null || true)
-  desired_redis_image=$(grep -m1 '^[[:space:]]*image:' kube/redis/redis-deployment.yml | awk '{print $2}')
-
-  if [[ -n "${current_redis_image}" && -n "${desired_redis_image}" && "${current_redis_image}" != "${desired_redis_image}" ]]; then
-    echo "Redis image changed (${current_redis_image} -> ${desired_redis_image}), recycling redis deployment while preserving PVC"
-
-    $kubectl delete deployment redis --ignore-not-found=true
-
-    while $kubectl get pods -l app=redis --no-headers 2>/dev/null | grep -q .; do
-      sleep 2
-    done
-  fi
-}
 
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
@@ -51,20 +30,29 @@ if [[ $1 == 'tear_down' ]]; then
   exit 0
 fi
 
+
 export KUBE_NAMESPACE=$1
 export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
 
-if [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
-  export REDIS_PERSISTENCE_ENABLED=true
-  export REDIS_PERSISTENCE_SIZE=1Gi
-elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
-  export REDIS_PERSISTENCE_ENABLED=true
-  export REDIS_PERSISTENCE_SIZE=5Gi
+if [[ ${KUBE_NAMESPACE} == ${STG_ENV} || ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
+  export REDIS_PERSISTENCE_ENABLED=${REDIS_PERSISTENCE_ENABLED:-true}
 else
   export REDIS_PERSISTENCE_ENABLED=false
 fi
+export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
+export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-gp2-encrypted-eu-west-2b}
+export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
+export REDIS_PERSISTENCE_ANNOTATIONS_FILE=${REDIS_PERSISTENCE_ANNOTATIONS_FILE:-}
 
-REDIS_PERSISTENCE_ENABLED=$(echo "$REDIS_PERSISTENCE_ENABLED" | tr '[:upper:]' '[:lower:]')
+if [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
+  export REDIS_PERSISTENCE_SIZE=5Gi
+else
+  export REDIS_PERSISTENCE_SIZE=1Gi
+fi
+
+if [[ (${KUBE_NAMESPACE} == ${STG_ENV} || ${KUBE_NAMESPACE} == ${PROD_ENV}) && ${REDIS_PERSISTENCE_ENABLED} == "true" && -z "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+  $kd -f $redis_storage_files
+fi
 
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/configmaps -f kube/certs
@@ -77,13 +65,13 @@ elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/app/ingress-internal.yml -f kube/app/networkpolicy-internal.yml
-  deploy_redis
-  $kd -f kube/html-pdf -f kube/file-vault -f kube/app/deployment.yml
+  $kd -f kube/html-pdf -f kube/file-vault 
+  $kd -f $redis_runtime_files -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/app/ingress-external.yml -f kube/app/networkpolicy-external.yml
-  deploy_redis
-  $kd -f kube/html-pdf -f kube/file-vault -f kube/app/deployment.yml
+  $kd -f kube/html-pdf -f kube/file-vault 
+  $kd -f $redis_runtime_files -f kube/app/deployment.yml
 fi
 
 sleep $READY_FOR_TEST_DELAY

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -17,6 +17,8 @@ export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
 
 REDIS_PERSISTENCE_ENABLED=$(echo "$REDIS_PERSISTENCE_ENABLED" | tr '[:upper:]' '[:lower:]')
 
+redis_runtime_files='kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml'
+
 deploy_redis() {
   if [[ "$REDIS_PERSISTENCE_ENABLED" == 'true' ]] && [[ -z "$REDIS_PERSISTENCE_EXISTING_CLAIM" ]]; then
     $kd -f kube/redis/redis-pvc.yml
@@ -62,10 +64,12 @@ REDIS_PERSISTENCE_ENABLED=$(echo "$REDIS_PERSISTENCE_ENABLED" | tr '[:upper:]' '
 
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/configmaps -f kube/certs
-  $kd -f kube/html-pdf -f kube/file-vault -f kube/app
+  $kd -f kube/html-pdf -f kube/file-vault 
+  $kd -f $redis_runtime_files -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
-  $kd -f kube/configmaps/configmap.yml  -f kube/app
+  $kd -f kube/configmaps/configmap.yml
   $kd -f kube/html-pdf -f kube/file-vault
+  $kd -f $redis_runtime_files -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/app/ingress-internal.yml -f kube/app/networkpolicy-internal.yml

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -7,32 +7,36 @@ export CONFIGMAP_VALUES=$HOF_CONFIG/configmap-values.yaml
 export NGINX_SETTINGS=$HOF_CONFIG/nginx-settings.yaml
 export FILEVAULT_NGINX_SETTINGS=$HOF_CONFIG/filevault-nginx-settings.yaml
 export FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/filevault-ingress-external-annotations.yaml
-
-kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
-
 export REDIS_PERSISTENCE_ENABLED=${REDIS_PERSISTENCE_ENABLED:-false}
 export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
 export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-gp2-encrypted}
 export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
 
-REDIS_PERSISTENCE_ENABLED=$(echo "$REDIS_PERSISTENCE_ENABLED" | tr '[:upper:]' '[:lower:]')
-
+kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
+redis_storage_files='kube/redis/redis-persistent-volume-claim.yml'
 redis_runtime_files='kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml'
 
-deploy_redis() {
-  if [[ "$REDIS_PERSISTENCE_ENABLED" == 'true' ]] && [[ -z "$REDIS_PERSISTENCE_EXISTING_CLAIM" ]]; then
-    $kd -f kube/redis/redis-pvc.yml
+recreate_redis_pvc_if_image_changed() {
+  if [[ ${REDIS_PERSISTENCE_ENABLED} != true ]]; then
+    return
   fi
 
-  $kd -f kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml
-}
-
-delete_redis() {
-  if [[ "$REDIS_PERSISTENCE_ENABLED" == 'true' ]] && [[ -z "$REDIS_PERSISTENCE_EXISTING_CLAIM" ]]; then
-    $kd --delete -f kube/redis/redis-pvc.yml
+  if [[ -n "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+    return
   fi
 
-  $kd --delete -f kube/redis/redis-deployment.yml -f kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml
+  current_redis_image=$($kubectl get deployment redis -o jsonpath='{.spec.template.spec.containers[?(@.name=="redis")].image}' 2>/dev/null || true)
+  desired_redis_image=$(grep -m1 '^[[:space:]]*image:' kube/redis/redis-deployment.yml | awk '{print $2}')
+
+  if [[ -n "${current_redis_image}" && -n "${desired_redis_image}" && "${current_redis_image}" != "${desired_redis_image}" ]]; then
+    echo "Redis image changed (${current_redis_image} -> ${desired_redis_image}), recycling redis deployment while preserving PVC"
+
+    $kubectl delete deployment redis --ignore-not-found=true
+
+    while $kubectl get pods -l app=redis --no-headers 2>/dev/null | grep -q .; do
+      sleep 2
+    done
+  fi
 }
 
 if [[ $1 == 'tear_down' ]]; then
@@ -50,12 +54,12 @@ fi
 export KUBE_NAMESPACE=$1
 export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
 
-if [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
-  export REDIS_PERSISTENCE_ENABLED=true
-  export REDIS_PERSISTENCE_SIZE=10Gi
-elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
+if [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   export REDIS_PERSISTENCE_ENABLED=true
   export REDIS_PERSISTENCE_SIZE=1Gi
+elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
+  export REDIS_PERSISTENCE_ENABLED=true
+  export REDIS_PERSISTENCE_SIZE=5Gi
 else
   export REDIS_PERSISTENCE_ENABLED=false
 fi


### PR DESCRIPTION
## What?

* Recent PVC updates pushed to the master branch accidentally removed the Redis deployment definitions, resulting in Redis not being deployed in both branch and UAT environments.


## Why?

Developers reported form failures accompanied by NGINX error messages.

Investigation showed Redis pods were missing from the Drone CI deployment output and can be noticed in namespace

Drone builds remained green because Redis wasn't included in the branch/UAT deploy scripts, so its absence went undetected.

The Redis deployment entries must be added back to restore expected application behaviour.

## How?

Redis deployments were reintroduced into deploy.sh, ensuring they are deployed before the application services to maintain correct startup order and dependency flow.

## Testing?

* Deployed Redis pod successfully to Branch namespace
* FMRF Form is accessible now

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
