### PR TITLE
Hot-Fix: UAT build teardown steps to unblock prod release

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -28,7 +28,7 @@ if [[ $1 == 'tear_down' ]]; then
   fi
 
   $kd --delete -f kube/configmaps/configmap.yml
-  $kd --delete -f kube/redis
+  $kd --delete -f $redis_runtime_files
   $kd --delete -f kube/html-pdf -f kube/file-vault -f kube/app
   echo "Torn Down Branch - ukviet-$DRONE_SOURCE_BRANCH.internal.$BRANCH_ENV.homeoffice.gov.uk"
   exit 0


### PR DESCRIPTION
## What?
* Tear down is trying to tear down the deployments from kube folder. PVC should be excluded from the tear down which are not part of branch deployment anymore

## Why?

* UAT builds are failing blocking prod releases

## How?

* Replace 

  $kd --delete -f kube/redis

 with

  $kd --delete -f $redis_runtime_files
  
  ensuring pvc are excluded

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
