### PR TITLE
HOT-FIX: Mismatch of PVC claim names

### DIFF
--- a/kube/redis/redis-persistent-volume.yml
+++ b/kube/redis/redis-persistent-volume.yml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: redis-pvc
+  name: redis-data
   {{ if ne .REDIS_PERSISTENCE_ANNOTATIONS_FILE "" }}
   annotations:
 {{ file .REDIS_PERSISTENCE_ANNOTATIONS_FILE | indent 4 }}


### PR DESCRIPTION
## What?

This pull request makes a small but important update to the Redis persistent volume claim configuration by renaming the PVC resource. The new name improves clarity and consistency in resource naming. 

## Why?

* Prod deployments blocked by this mismatch

## How?

- Renamed the persistent volume claim from `redis-pvc` to `redis-data` in `kube/redis/redis-persistent-volume.yml` for better clarity and alignment with naming conventions.

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
